### PR TITLE
M19: Fix ESC dismiss on Mac sheets + grid card tap target

### DIFF
--- a/forager/App/foragerApp.swift
+++ b/forager/App/foragerApp.swift
@@ -265,6 +265,7 @@ struct foragerApp: App {
                                 .toolbar {
                                     ToolbarItem(placement: .cancellationAction) {
                                         Button("Done") { showSearch = false }
+                                            .keyboardShortcut(.cancelAction)
                                     }
                                 }
                         }

--- a/forager/Views/Grocery/ManageStoresView.swift
+++ b/forager/Views/Grocery/ManageStoresView.swift
@@ -558,6 +558,7 @@ struct StoreColorPickerSheet: View {
             .toolbar {
                 ToolbarItem(placement: .cancellationAction) {
                     Button("Done") { dismiss() }
+                        .keyboardShortcut(.cancelAction)
                 }
             }
         }

--- a/forager/Views/Grocery/StoreAssignmentModal.swift
+++ b/forager/Views/Grocery/StoreAssignmentModal.swift
@@ -92,6 +92,7 @@ struct StoreAssignmentModal: View {
             .toolbar {
                 ToolbarItem(placement: .cancellationAction) {
                     Button("Cancel") { dismiss() }
+                        .keyboardShortcut(.cancelAction)
                 }
             }
         }

--- a/forager/Views/Grocery/WeeklyListsView.swift
+++ b/forager/Views/Grocery/WeeklyListsView.swift
@@ -464,6 +464,7 @@ private struct MealPlanGrocerySheet: View {
             .toolbar {
                 ToolbarItem(placement: .cancellationAction) {
                     Button("Cancel") { dismiss() }
+                        .keyboardShortcut(.cancelAction)
                 }
             }
         }

--- a/forager/Views/Import/RecipeBrowserView.swift
+++ b/forager/Views/Import/RecipeBrowserView.swift
@@ -45,6 +45,7 @@ struct RecipeBrowserView: View {
             .toolbar {
                 ToolbarItem(placement: .cancellationAction) {
                     Button("Done") { dismiss() }
+                        .keyboardShortcut(.cancelAction)
                 }
                 ToolbarItem(placement: .primaryAction) {
                     Button {

--- a/forager/Views/Import/RecipeImportPreviewView.swift
+++ b/forager/Views/Import/RecipeImportPreviewView.swift
@@ -229,6 +229,7 @@ struct RecipeImportPreviewView: View {
         .toolbar {
             ToolbarItem(placement: .cancellationAction) {
                 Button("Cancel") { onCancel() }
+                    .keyboardShortcut(.cancelAction)
             }
             ToolbarItem(placement: .confirmationAction) {
                 Button("Save") { saveWithCategories() }
@@ -1001,6 +1002,7 @@ struct RecipeImportPreviewView: View {
             .toolbar {
                 ToolbarItem(placement: .cancellationAction) {
                     Button("Cancel") { categoryPickerIndex = nil }
+                        .keyboardShortcut(.cancelAction)
                 }
             }
         }

--- a/forager/Views/Import/RecipeImportSheet.swift
+++ b/forager/Views/Import/RecipeImportSheet.swift
@@ -92,6 +92,7 @@ struct RecipeImportSheet: View {
                 ToolbarItem(placement: .cancellationAction) {
                     if !importService.state.isLoading && !importService.state.isReviewing {
                         Button("Cancel") { handleCancel() }
+                            .keyboardShortcut(.cancelAction)
                     }
                 }
             }

--- a/forager/Views/MealPlanning/CreateMealPlanSheet.swift
+++ b/forager/Views/MealPlanning/CreateMealPlanSheet.swift
@@ -61,8 +61,9 @@ struct CreateMealPlanSheet: View {
                             Button("Cancel") {
                                 dismiss()
                             }
+                            .keyboardShortcut(.cancelAction)
                         }
-                        
+
                         ToolbarItem(placement: .confirmationAction) {
                             Button("Create") {
                                 createMealPlan()

--- a/forager/Views/MealPlanning/MealPlanIngredientSelectionView.swift
+++ b/forager/Views/MealPlanning/MealPlanIngredientSelectionView.swift
@@ -51,6 +51,7 @@ struct MealPlanIngredientSelectionView: View {
             .toolbar {
                 ToolbarItem(placement: .cancellationAction) {
                     Button("Cancel") { dismiss() }
+                        .keyboardShortcut(.cancelAction)
                 }
             }
         }

--- a/forager/Views/MealPlanning/SelectMealPlanSheet.swift
+++ b/forager/Views/MealPlanning/SelectMealPlanSheet.swift
@@ -71,8 +71,9 @@ struct SelectMealPlanSheet: View {
                     Button("Cancel") {
                         dismiss()
                     }
+                    .keyboardShortcut(.cancelAction)
                 }
-                
+
                 ToolbarItem(placement: .confirmationAction) {
                     Button("Add") {
                         addRecipeToPlan()

--- a/forager/Views/Recipes/CreateRecipeView.swift
+++ b/forager/Views/Recipes/CreateRecipeView.swift
@@ -598,6 +598,7 @@ struct CreateRecipeView: View {
             .toolbar {
                 ToolbarItem(placement: .cancellationAction) {
                     Button("Cancel") { categoryPickerIngredientId = nil }
+                        .keyboardShortcut(.cancelAction)
                 }
             }
         }

--- a/forager/Views/Recipes/EditRecipeView.swift
+++ b/forager/Views/Recipes/EditRecipeView.swift
@@ -617,6 +617,7 @@ struct EditRecipeView: View {
             .toolbar {
                 ToolbarItem(placement: .cancellationAction) {
                     Button("Cancel") { categoryPickerIngredientId = nil }
+                        .keyboardShortcut(.cancelAction)
                 }
             }
         }

--- a/forager/Views/Recipes/RecipeListView.swift
+++ b/forager/Views/Recipes/RecipeListView.swift
@@ -330,6 +330,7 @@ struct RecipeListView: View {
                             RecipeGridCard(recipe: recipe)
                         }
                         .buttonStyle(.plain)
+                        .contentShape(Rectangle())
                         .contextMenu {
                             Button {
                                 selectedRecipeForMealPlan = recipe
@@ -1728,6 +1729,7 @@ struct RecipeDetailView: View {
                 }
                 ToolbarItem(placement: .cancellationAction) {
                     Button("Cancel") { showCustomScalePicker = false }
+                        .keyboardShortcut(.cancelAction)
                 }
             }
         }
@@ -2221,6 +2223,7 @@ struct RecipeDetailView: View {
             .toolbar {
                 ToolbarItem(placement: .cancellationAction) {
                     Button("Cancel") { categoryPickerIngredientId = nil }
+                        .keyboardShortcut(.cancelAction)
                 }
             }
         }

--- a/forager/Views/Settings/SettingsView.swift
+++ b/forager/Views/Settings/SettingsView.swift
@@ -845,9 +845,10 @@ struct CreateHouseholdSheet: View {
                     Button("Cancel") {
                         dismiss()
                     }
+                    .keyboardShortcut(.cancelAction)
                     .disabled(isCreating)
                 }
-                
+
                 ToolbarItem(placement: .confirmationAction) {
                     Button("Create") {
                         checkPersonalDataAndCreate()


### PR DESCRIPTION
## Summary
- Fix ESC key not dismissing sheets on Mac (cowork QA TC-7 failure)
- Fix recipe grid card tap target only registering on text, not full card area (TC-3 observation)

## Changes
- Add `.keyboardShortcut(.cancelAction)` to 16 Cancel/Done buttons across 12 files — ESC now dismisses all sheets on Mac
- Add `.contentShape(Rectangle())` to recipe grid card `NavigationLink` — entire card area is tappable

## Test plan
- [x] iOS build succeeds
- [ ] ESC dismisses Import Recipe sheet on Mac
- [ ] ESC dismisses Create Meal Plan sheet on Mac
- [ ] Recipe grid cards tappable in image area on Mac