### PR TITLE
FUI-1.9.2: Fix meal plan overlap and grocery list navigation

### DIFF
--- a/Services/MealPlanService.swift
+++ b/Services/MealPlanService.swift
@@ -721,19 +721,28 @@ class MealPlanService: ObservableObject {
     }
     
     // FUI-1.9: Assign a recipe to today from the dashboard.
-    // Auto-creates a meal plan if none covers today.
+    // Finds any existing plan covering today, or creates a new one.
     @discardableResult
     func assignRecipeToToday(recipe: Recipe) -> PlannedMeal? {
         let today = Calendar.current.startOfDay(for: Date())
 
-        // Find or create a meal plan covering today
+        // Search for ANY plan covering today (not just activeMealPlan cache)
         var plan: MealPlan?
-        if let active = activeMealPlan,
-           let start = active.startDate,
-           let end = Calendar.current.date(byAdding: .day, value: Int(active.duration), to: start),
-           today >= Calendar.current.startOfDay(for: start) && today < Calendar.current.startOfDay(for: end) {
-            plan = active
-        } else {
+        let fetchRequest: NSFetchRequest<MealPlan> = MealPlan.fetchRequest()
+        fetchRequest.predicate = NSCompoundPredicate(andPredicateWithSubpredicates: [
+            NSPredicate(format: "isCompleted == NO"),
+            householdKeyPredicate()
+        ])
+        if let allPlans = try? context.fetch(fetchRequest) {
+            plan = allPlans.first { mp in
+                guard let start = mp.startDate,
+                      let end = Calendar.current.date(byAdding: .day, value: Int(mp.duration), to: start) else { return false }
+                return today >= Calendar.current.startOfDay(for: start) && today < Calendar.current.startOfDay(for: end)
+            }
+        }
+
+        // Only create if no plan covers today
+        if plan == nil {
             plan = createMealPlan()
         }
 

--- a/forager/Views/Dashboard/DashboardView.swift
+++ b/forager/Views/Dashboard/DashboardView.swift
@@ -168,7 +168,7 @@ struct DashboardView: View {
 
                 // 2. Shopping List (always visible)
                 if let list = activeGroceryList {
-                    Button { selectedTab = .lists } label: {
+                    NavigationLink(destination: GroceryListDetailView(weeklyList: list)) {
                         groceryRunCard(list: list)
                     }
                     .buttonStyle(.plain)


### PR DESCRIPTION
## Summary
- Fix duplicate meal plan creation when assigning recipe from dashboard
- Fix grocery list card navigating to list detail instead of tab

## Changes
- `MealPlanService.assignRecipeToToday()`: fetch all non-completed plans from Core Data and check date coverage instead of relying on `activeMealPlan` cache
- `DashboardView`: grocery list card uses `NavigationLink` to `GroceryListDetailView` instead of tab switch

## Test plan
- [x] iOS build succeeds
- [ ] Assign recipe from dashboard with existing plan covering today: no new plan created
- [ ] Tap grocery list card on dashboard: navigates into that specific list