### PR TITLE
FUI-1.9.4: Grocery list section cards via insetGrouped

### DIFF
--- a/forager/Views/Grocery/GroceryListDetailView.swift
+++ b/forager/Views/Grocery/GroceryListDetailView.swift
@@ -440,7 +440,7 @@ struct GroceryListDetailView: View {
                 }
             }
         }
-        .listStyle(.plain)
+        .listStyle(.insetGrouped)
         .scrollContentBackground(.hidden)
         .background(ForagerTheme.backgroundCanvas)
     }
@@ -453,7 +453,8 @@ struct GroceryListDetailView: View {
             showRecipeSources: preferencesService.showRecipeSources,
             storeColorHex: hasStores ? item.store?.color : nil
         )
-        .listRowBackground(Color.clear)
+        .listRowBackground(ForagerTheme.surfacePrimary)
+        .listRowSeparatorTint(ForagerTheme.borderSubtle)
         .swipeActions(edge: .leading) {
             Button {
                 toggleItemCompletion(item)


### PR DESCRIPTION
## Summary
- Switch grocery list detail from flat plain list to insetGrouped section cards
- Items grouped within rounded section containers with proper theme colors

## Changes
- `.listStyle(.plain)` → `.listStyle(.insetGrouped)` for native section card styling
- `.listRowBackground(ForagerTheme.surfacePrimary)` for themed row fill
- `.listRowSeparatorTint(ForagerTheme.borderSubtle)` for subtle dividers

## Test plan
- [x] iOS build succeeds
- [ ] Light mode: sections render as rounded cards on beige canvas
- [ ] Dark mode: sections render with proper dark surface colors
- [ ] Swipe actions still work (complete, delete)
- [ ] Store grouping mode: store sections contain category sub-sections