### PR TITLE
FUI-1.9.6: Hide staggered row separators in grocery list

### DIFF
--- a/forager/Views/Grocery/GroceryListDetailView.swift
+++ b/forager/Views/Grocery/GroceryListDetailView.swift
@@ -454,7 +454,7 @@ struct GroceryListDetailView: View {
             storeColorHex: hasStores ? item.store?.color : nil
         )
         .listRowBackground(ForagerTheme.surfacePrimary)
-        .listRowSeparatorTint(ForagerTheme.borderSubtle)
+        .listRowSeparator(.hidden)
         .swipeActions(edge: .leading) {
             Button {
                 toggleItemCompletion(item)


### PR DESCRIPTION
## Summary
- Hide inter-item separator lines in grocery list detail view
- insetGrouped section cards provide visual grouping without staggered separators

## Test plan
- [x] iOS build succeeds
- [ ] No separator lines between grocery items within sections
- [ ] Section card boundaries still clearly visible