### PR TITLE
M18.2: Add protected No Store default entity (schema v12)

### DIFF
--- a/Models/Store+CoreDataProperties.swift
+++ b/Models/Store+CoreDataProperties.swift
@@ -15,6 +15,7 @@ extension Store {
     }
 
     @NSManaged public var id: UUID?
+    @NSManaged public var isDefault: Bool
     @NSManaged public var name: String?
     @NSManaged public var color: String?
     @NSManaged public var sortOrder: Int16

--- a/Services/GroceryListItemService.swift
+++ b/Services/GroceryListItemService.swift
@@ -310,7 +310,10 @@ class GroceryListItemService: ObservableObject {
         for template: IngredientTemplate?,
         targetList: WeeklyList
     ) -> Store? {
-        guard let store = template?.preferredStore else { return nil }
+        guard let store = template?.preferredStore else {
+            // M18.2: Return default "No Store" entity instead of nil
+            return lookupDefaultStore(householdKey: targetList.householdKey)
+        }
 
         let targetPersistentStore = targetList.objectID.persistentStore
         let storePersistentStore = store.objectID.persistentStore
@@ -335,6 +338,18 @@ class GroceryListItemService: ObservableObject {
         }
         request.fetchLimit = 1
         return (try? viewContext.fetch(request))?.first
+    }
+
+    // M18.2: Lookup default "No Store" entity by isDefault flag
+    private func lookupDefaultStore(householdKey: String?) -> Store? {
+        let request: NSFetchRequest<Store> = Store.fetchRequest()
+        if let key = householdKey {
+            request.predicate = NSPredicate(format: "isDefault == YES AND householdKey == %@", key)
+        } else {
+            request.predicate = NSPredicate(format: "isDefault == YES AND householdKey == nil")
+        }
+        request.fetchLimit = 1
+        return try? viewContext.fetch(request).first
     }
 
     // MARK: - Template Helpers

--- a/Services/HouseholdService.swift
+++ b/Services/HouseholdService.swift
@@ -712,6 +712,7 @@ class HouseholdService: ObservableObject {
             // copyPersonalDataToHousehold moved all personal categories into the household,
             // so a clean delete leaves zero categories. Re-seed so the user has defaults.
             try DefaultSeeder.ensureUncategorizedExists(in: viewContext)
+            try DefaultSeeder.ensureNoStoreExists(in: viewContext)
             DefaultSeeder.resetSeedingForRestore()
             try DefaultSeeder.seedDefaultsIfNeeded(in: viewContext)
         }

--- a/Services/Persistence/DefaultSeeder.swift
+++ b/Services/Persistence/DefaultSeeder.swift
@@ -170,6 +170,33 @@ final class DefaultSeeder {
         #endif
     }
 
+    // MARK: - No Store Safety Net
+
+    /// M18.2: Ensure "No Store" default store exists in the personal store.
+    /// Mirrors ensureUncategorizedExists for categories.
+    /// Runs every startup — cheap fetch, no-op if it exists.
+    static func ensureNoStoreExists(in context: NSManagedObjectContext) throws {
+        let request: NSFetchRequest<Store> = Store.fetchRequest()
+        request.predicate = NSPredicate(format: "isDefault == YES AND householdKey == nil")
+        request.fetchLimit = 1
+
+        let existing = (try? context.fetch(request))?.first
+        if existing != nil { return }
+
+        let noStore = Store(context: context)
+        noStore.id = UUID()
+        noStore.name = "No Store"
+        noStore.color = "#9E9E9E"
+        noStore.sortOrder = 999
+        noStore.isDefault = true
+        noStore.dateCreated = Date()
+        noStore.updatedAt = Date()
+
+        #if DEBUG
+        print("🏪 M18.2: Created missing 'No Store' default store in personal store")
+        #endif
+    }
+
     // MARK: - Category Seeding (Phase 3.1: Using Repository)
     
     /// M7.2.3 Phase 3.1: Seeds default categories using HouseholdCategoryRepository

--- a/Services/Persistence/PersistenceController.swift
+++ b/Services/Persistence/PersistenceController.swift
@@ -442,6 +442,9 @@ final class PersistenceController: ObservableObject {
                 // M9.12: Ensure "Uncategorized" always exists (survives leave-household)
                 try DefaultSeeder.ensureUncategorizedExists(in: context)
 
+                // M18.2: Ensure "No Store" default store always exists
+                try DefaultSeeder.ensureNoStoreExists(in: context)
+
                 // M7.6.6: Migrate tags from sourceURL hack to dedicated tags attribute
                 Self.migrateSourceURLTagsIfNeeded(in: context)
 

--- a/Services/StoreService.swift
+++ b/Services/StoreService.swift
@@ -75,10 +75,31 @@ class StoreService: ObservableObject {
         return nil
     }
 
+    /// M18.2: Lookup the default "No Store" entity for the current household scope.
+    func lookupDefaultStore() -> Store? {
+        let request: NSFetchRequest<Store> = Store.fetchRequest()
+        if let key = householdKeyProvider?() {
+            request.predicate = NSPredicate(format: "isDefault == YES AND householdKey == %@", key)
+        } else {
+            request.predicate = NSPredicate(format: "isDefault == YES AND householdKey == nil")
+        }
+        request.fetchLimit = 1
+        return try? viewContext.fetch(request).first
+    }
+
     /// Deletes a store. If `reassignTo` is provided, templates currently assigned
     /// to the deleted store are reassigned to it. Otherwise, templates are unassigned.
+    /// Protected stores (isDefault == true) cannot be deleted.
     func deleteStore(_ store: Store, reassignTo replacement: Store? = nil) {
         clearError()
+
+        // M18.2: Protect default store from deletion
+        guard !store.isDefault else {
+            #if DEBUG
+            print("⚠️ Cannot delete default store '\(store.name ?? "")'")
+            #endif
+            return
+        }
 
         // Reassign templates before deletion
         if let templates = store.ingredientTemplates as? Set<IngredientTemplate> {

--- a/forager/Views/Grocery/ManageStoresView.swift
+++ b/forager/Views/Grocery/ManageStoresView.swift
@@ -29,10 +29,11 @@ struct ManageStoresView: View {
         animation: .default
     ) private var allStores: FetchedResults<Store>
 
-    // ADR 013: Filter by current household scope
+    // ADR 013: Filter by current household scope, exclude default "No Store"
     private var stores: [Store] {
         let currentHouseholdKey = householdService.currentHouseholdKey
         return allStores.filter { store in
+            guard !store.isDefault else { return false }
             if let householdKey = currentHouseholdKey {
                 return store.householdKey == householdKey
             } else {

--- a/forager/Views/Grocery/StoreAssignmentModal.swift
+++ b/forager/Views/Grocery/StoreAssignmentModal.swift
@@ -42,9 +42,9 @@ struct StoreAssignmentModal: View {
     var body: some View {
         NavigationStack {
             List {
-                // "No Store" option
+                // "No Store" option — assigns the default store entity
                 Button {
-                    assignStore(nil)
+                    assignStore(storeService.lookupDefaultStore())
                 } label: {
                     HStack(spacing: ForagerTheme.Spacing.sm) {
                         Circle()
@@ -54,7 +54,7 @@ struct StoreAssignmentModal: View {
                             .font(ForagerTheme.bodyFont)
                             .foregroundStyle(ForagerTheme.textSecondary)
                         Spacer()
-                        if item.store == nil {
+                        if item.store?.isDefault == true {
                             Image(systemName: "checkmark")
                                 .foregroundStyle(ForagerTheme.accentPrimary)
                                 .font(.caption)
@@ -63,8 +63,8 @@ struct StoreAssignmentModal: View {
                 }
                 .listRowBackground(Color.clear)
 
-                // Store options
-                ForEach(stores) { store in
+                // Store options (exclude default "No Store")
+                ForEach(stores.filter { !$0.isDefault }) { store in
                     Button {
                         assignStore(store)
                     } label: {

--- a/forager/Views/Grocery/StoreChangeModal.swift
+++ b/forager/Views/Grocery/StoreChangeModal.swift
@@ -324,7 +324,7 @@ struct StorePickerView: View {
 
     var body: some View {
         List {
-            ForEach(stores, id: \.objectID) { store in
+            ForEach(stores.filter { !$0.isDefault }, id: \.objectID) { store in
                 Button {
                     onStoreSelected(store.objectID)
                     dismiss()
@@ -348,7 +348,12 @@ struct StorePickerView: View {
             }
 
             Button("No Store") {
-                onStoreSelected(nil)
+                // M18.2: Assign the default "No Store" entity instead of nil
+                if let defaultStore = stores.first(where: { $0.isDefault }) {
+                    onStoreSelected(defaultStore.objectID)
+                } else {
+                    onStoreSelected(nil)
+                }
                 dismiss()
             }
             .foregroundStyle(ForagerTheme.textSecondary)

--- a/forager/forager.xcdatamodeld/.xccurrentversion
+++ b/forager/forager.xcdatamodeld/.xccurrentversion
@@ -3,6 +3,6 @@
 <plist version="1.0">
 <dict>
 	<key>_XCCurrentVersionName</key>
-	<string>forager 11.xcdatamodel</string>
+	<string>forager 12.xcdatamodel</string>
 </dict>
 </plist>

--- a/forager/forager.xcdatamodeld/forager 12.xcdatamodel/contents
+++ b/forager/forager.xcdatamodeld/forager 12.xcdatamodel/contents
@@ -1,0 +1,250 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="24299" systemVersion="25B78" minimumToolsVersion="Automatic" sourceLanguage="Swift" usedWithCloudKit="YES" userDefinedModelVersionIdentifier="">
+    <entity name="Category" representedClassName="Category" syncable="YES">
+        <attribute name="color" optional="YES" attributeType="String"/>
+        <attribute name="dateCreated" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="householdKey" optional="YES" attributeType="String"/>
+        <attribute name="id" optional="YES" attributeType="UUID" usesScalarValueType="NO"/>
+        <attribute name="isDefault" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES"/>
+        <attribute name="name" optional="YES" attributeType="String"/>
+        <attribute name="normalizedName" optional="YES" attributeType="String"/>
+        <attribute name="sortOrder" attributeType="Integer 16" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="updatedAt" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
+        <relationship name="groceryItems" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="GroceryItem" inverseName="categoryEntity" inverseEntity="GroceryItem"/>
+        <relationship name="groceryListItems" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="GroceryListItem" inverseName="categoryEntity" inverseEntity="GroceryListItem"/>
+        <relationship name="household" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Household" inverseName="categories" inverseEntity="Household"/>
+        <relationship name="ingredientTemplates" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="IngredientTemplate" inverseName="categoryEntity" inverseEntity="IngredientTemplate"/>
+        <fetchIndex name="byCategorySortOrder">
+            <fetchIndexElement property="sortOrder" type="Binary" order="ascending"/>
+            <fetchIndexElement property="name" type="Binary" order="ascending"/>
+            <fetchIndexElement property="isDefault" type="Binary" order="ascending"/>
+            <fetchIndexElement property="normalizedName" type="Binary" order="ascending"/>
+        </fetchIndex>
+    </entity>
+    <entity name="GroceryItem" representedClassName="GroceryItem" syncable="YES">
+        <attribute name="category" optional="YES" attributeType="String"/>
+        <attribute name="dateCreated" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="id" optional="YES" attributeType="UUID" usesScalarValueType="NO"/>
+        <attribute name="isStaple" optional="YES" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES"/>
+        <attribute name="lastPurchased" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="name" optional="YES" attributeType="String"/>
+        <relationship name="categoryEntity" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Category" inverseName="groceryItems" inverseEntity="Category"/>
+        <fetchIndex name="byStaplesCategoryOrder">
+            <fetchIndexElement property="isStaple" type="Binary" order="ascending"/>
+            <fetchIndexElement property="category" type="Binary" order="ascending"/>
+            <fetchIndexElement property="name" type="Binary" order="ascending"/>
+            <fetchIndexElement property="lastPurchased" type="Binary" order="ascending"/>
+        </fetchIndex>
+    </entity>
+    <entity name="GroceryListItem" representedClassName="GroceryListItem" syncable="YES">
+        <attribute name="categoryName" optional="YES" attributeType="String"/>
+        <attribute name="dateCompleted" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="displayText" attributeType="String" defaultValueString="&quot;&quot;"/>
+        <attribute name="householdKey" optional="YES" attributeType="String"/>
+        <attribute name="id" optional="YES" attributeType="UUID" usesScalarValueType="NO"/>
+        <attribute name="isCompleted" optional="YES" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES"/>
+        <attribute name="isParseable" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES"/>
+        <attribute name="name" optional="YES" attributeType="String"/>
+        <attribute name="numericValue" optional="YES" attributeType="Double" usesScalarValueType="YES"/>
+        <attribute name="parseConfidence" attributeType="Float" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="sortOrder" optional="YES" attributeType="Integer 16" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="source" optional="YES" attributeType="String"/>
+        <attribute name="standardUnit" optional="YES" attributeType="String"/>
+        <relationship name="categoryEntity" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Category" inverseName="groceryListItems" inverseEntity="Category"/>
+        <relationship name="household" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Household" inverseName="groceryListItems" inverseEntity="Household"/>
+        <relationship name="sourceRecipes" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="Recipe" inverseName="groceryListItems" inverseEntity="Recipe"/>
+        <relationship name="store" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Store" inverseName="groceryListItems" inverseEntity="Store"/>
+        <relationship name="weeklyList" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="WeeklyList" inverseName="items" inverseEntity="WeeklyList"/>
+        <fetchIndex name="byQuantityFields">
+            <fetchIndexElement property="numericValue" type="Binary" order="ascending"/>
+            <fetchIndexElement property="standardUnit" type="Binary" order="ascending"/>
+        </fetchIndex>
+    </entity>
+    <entity name="Household" representedClassName="Household" syncable="YES">
+        <attribute name="createdDate" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="id" optional="YES" attributeType="UUID" usesScalarValueType="NO"/>
+        <attribute name="lastInviteDate" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="llmAPIKey" optional="YES" attributeType="String"/>
+        <attribute name="name" attributeType="String" defaultValueString="&quot;&quot;"/>
+        <attribute name="ownerEmail" attributeType="String" defaultValueString="&quot;&quot;"/>
+        <attribute name="ownerRecordName" optional="YES" attributeType="String"/>
+        <attribute name="shareRecord" optional="YES" attributeType="Binary" allowsExternalBinaryDataStorage="YES"/>
+        <relationship name="categories" optional="YES" toMany="YES" deletionRule="Cascade" destinationEntity="Category" inverseName="household" inverseEntity="Category"/>
+        <relationship name="groceryListItems" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="GroceryListItem" inverseName="household" inverseEntity="GroceryListItem"/>
+        <relationship name="ingredients" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="Ingredient" inverseName="household" inverseEntity="Ingredient"/>
+        <relationship name="ingredientTemplates" optional="YES" toMany="YES" deletionRule="Cascade" destinationEntity="IngredientTemplate" inverseName="household" inverseEntity="IngredientTemplate"/>
+        <relationship name="mealPlans" optional="YES" toMany="YES" deletionRule="Cascade" destinationEntity="MealPlan" inverseName="household" inverseEntity="MealPlan"/>
+        <relationship name="members" optional="YES" toMany="YES" deletionRule="Cascade" destinationEntity="HouseholdMember" inverseName="household" inverseEntity="HouseholdMember"/>
+        <relationship name="plannedMeals" optional="YES" toMany="YES" deletionRule="Cascade" destinationEntity="PlannedMeal" inverseName="household" inverseEntity="PlannedMeal"/>
+        <relationship name="preferences" optional="YES" maxCount="1" deletionRule="Cascade" destinationEntity="UserPreferences" inverseName="household" inverseEntity="UserPreferences"/>
+        <relationship name="recipes" optional="YES" toMany="YES" deletionRule="Cascade" destinationEntity="Recipe" inverseName="household" inverseEntity="Recipe"/>
+        <relationship name="stores" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="Store" inverseName="household" inverseEntity="Store"/>
+        <relationship name="weeklyLists" optional="YES" toMany="YES" deletionRule="Cascade" destinationEntity="WeeklyList" inverseName="household" inverseEntity="WeeklyList"/>
+    </entity>
+    <entity name="HouseholdMember" representedClassName="HouseholdMember" syncable="YES">
+        <attribute name="displayName" optional="YES" attributeType="String"/>
+        <attribute name="email" attributeType="String" defaultValueString="&quot;&quot;"/>
+        <attribute name="id" optional="YES" attributeType="UUID" usesScalarValueType="NO"/>
+        <attribute name="invitedDate" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="joinedDate" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="role" optional="YES" attributeType="String"/>
+        <attribute name="status" attributeType="String" defaultValueString="&quot;pending&quot;"/>
+        <relationship name="household" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Household" inverseName="members" inverseEntity="Household"/>
+    </entity>
+    <entity name="Ingredient" representedClassName="Ingredient" syncable="YES">
+        <attribute name="displayText" attributeType="String" defaultValueString="&quot;&quot;"/>
+        <attribute name="householdKey" optional="YES" attributeType="String"/>
+        <attribute name="id" optional="YES" attributeType="UUID" usesScalarValueType="NO"/>
+        <attribute name="isParseable" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES"/>
+        <attribute name="name" optional="YES" attributeType="String"/>
+        <attribute name="notes" optional="YES" attributeType="String"/>
+        <attribute name="numericValue" optional="YES" attributeType="Double" usesScalarValueType="YES"/>
+        <attribute name="parseConfidence" attributeType="Float" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="sortOrder" optional="YES" attributeType="Integer 16" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="standardUnit" optional="YES" attributeType="String"/>
+        <relationship name="household" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Household" inverseName="ingredients" inverseEntity="Household"/>
+        <relationship name="ingredientTemplate" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="IngredientTemplate" inverseName="ingredients" inverseEntity="IngredientTemplate"/>
+        <relationship name="recipe" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Recipe" inverseName="ingredients" inverseEntity="Recipe"/>
+        <fetchIndex name="byQuantityFields">
+            <fetchIndexElement property="numericValue" type="Binary" order="ascending"/>
+            <fetchIndexElement property="standardUnit" type="Binary" order="ascending"/>
+            <fetchIndexElement property="isParseable" type="Binary" order="ascending"/>
+        </fetchIndex>
+    </entity>
+    <entity name="IngredientTemplate" representedClassName="IngredientTemplate" syncable="YES">
+        <attribute name="canonicalName" optional="YES" attributeType="String"/>
+        <attribute name="category" optional="YES" attributeType="String"/>
+        <attribute name="dateCreated" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="householdKey" optional="YES" attributeType="String"/>
+        <attribute name="id" optional="YES" attributeType="UUID" usesScalarValueType="NO"/>
+        <attribute name="isStaple" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES"/>
+        <attribute name="name" optional="YES" attributeType="String"/>
+        <attribute name="updatedAt" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="usageCount" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
+        <relationship name="categoryEntity" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Category" inverseName="ingredientTemplates" inverseEntity="Category"/>
+        <relationship name="household" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Household" inverseName="ingredientTemplates" inverseEntity="Household"/>
+        <relationship name="ingredients" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="Ingredient" inverseName="ingredientTemplate" inverseEntity="Ingredient"/>
+        <relationship name="preferredStore" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Store" inverseName="ingredientTemplates" inverseEntity="Store"/>
+        <fetchIndex name="byTemplateSearch">
+            <fetchIndexElement property="name" type="Binary" order="ascending"/>
+            <fetchIndexElement property="category" type="Binary" order="ascending"/>
+            <fetchIndexElement property="usageCount" type="Binary" order="descending"/>
+        </fetchIndex>
+        <fetchIndex name="byIngredientManagement">
+            <fetchIndexElement property="isStaple" type="Binary" order="ascending"/>
+            <fetchIndexElement property="category" type="Binary" order="ascending"/>
+            <fetchIndexElement property="name" type="Binary" order="ascending"/>
+            <fetchIndexElement property="usageCount" type="Binary" order="descending"/>
+        </fetchIndex>
+        <fetchIndex name="byCanonicalName">
+            <fetchIndexElement property="canonicalName" type="Binary" order="ascending"/>
+        </fetchIndex>
+    </entity>
+    <entity name="MealPlan" representedClassName="MealPlan" syncable="YES">
+        <attribute name="completedDate" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="createdDate" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="duration" attributeType="Integer 16" defaultValueString="7" usesScalarValueType="YES"/>
+        <attribute name="householdKey" optional="YES" attributeType="String"/>
+        <attribute name="id" optional="YES" attributeType="UUID" usesScalarValueType="NO"/>
+        <attribute name="isActive" attributeType="Boolean" defaultValueString="YES" usesScalarValueType="YES"/>
+        <attribute name="isCompleted" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES"/>
+        <attribute name="name" optional="YES" attributeType="String"/>
+        <attribute name="startDate" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
+        <relationship name="household" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Household" inverseName="mealPlans" inverseEntity="Household"/>
+        <relationship name="plannedMeals" optional="YES" toMany="YES" deletionRule="Cascade" destinationEntity="PlannedMeal" inverseName="mealPlan" inverseEntity="PlannedMeal"/>
+        <fetchIndex name="byIsActiveAndStartDate">
+            <fetchIndexElement property="isActive" type="Binary" order="ascending"/>
+            <fetchIndexElement property="startDate" type="Binary" order="ascending"/>
+        </fetchIndex>
+    </entity>
+    <entity name="PlannedMeal" representedClassName="PlannedMeal" syncable="YES">
+        <attribute name="completedDate" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="createdDate" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="date" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="householdKey" optional="YES" attributeType="String"/>
+        <attribute name="id" optional="YES" attributeType="UUID" usesScalarValueType="NO"/>
+        <attribute name="isCompleted" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES"/>
+        <attribute name="mealType" optional="YES" attributeType="String"/>
+        <attribute name="notes" optional="YES" attributeType="String"/>
+        <attribute name="quickOption" optional="YES" attributeType="String"/>
+        <attribute name="scaleFactor" attributeType="Double" defaultValueString="1" usesScalarValueType="YES"/>
+        <attribute name="servings" attributeType="Integer 16" defaultValueString="4" usesScalarValueType="YES"/>
+        <attribute name="slotKey" optional="YES" attributeType="String"/>
+        <relationship name="household" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Household" inverseName="plannedMeals" inverseEntity="Household"/>
+        <relationship name="mealPlan" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="MealPlan" inverseName="plannedMeals" inverseEntity="MealPlan"/>
+        <relationship name="recipe" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Recipe" inverseName="plannedMeals" inverseEntity="Recipe"/>
+        <fetchIndex name="bydateandisCompleted">
+            <fetchIndexElement property="date" type="Binary" order="ascending"/>
+            <fetchIndexElement property="isCompleted" type="Binary" order="ascending"/>
+        </fetchIndex>
+        <fetchIndex name="bySlotKey">
+            <fetchIndexElement property="slotKey" type="Binary" order="ascending"/>
+        </fetchIndex>
+    </entity>
+    <entity name="Recipe" representedClassName="Recipe" syncable="YES">
+        <attribute name="author" optional="YES" attributeType="String"/>
+        <attribute name="cookTime" optional="YES" attributeType="Integer 16" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="dateCreated" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="householdKey" optional="YES" attributeType="String"/>
+        <attribute name="id" optional="YES" attributeType="UUID" usesScalarValueType="NO"/>
+        <attribute name="imageURL" optional="YES" attributeType="String"/>
+        <attribute name="instructions" optional="YES" attributeType="String"/>
+        <attribute name="isFavorite" optional="YES" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES"/>
+        <attribute name="lastUsed" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="prepTime" optional="YES" attributeType="Integer 16" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="servings" optional="YES" attributeType="Integer 16" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="sourceURL" optional="YES" attributeType="String"/>
+        <attribute name="tags" optional="YES" attributeType="String"/>
+        <attribute name="title" optional="YES" attributeType="String"/>
+        <attribute name="usageCount" optional="YES" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES"/>
+        <relationship name="groceryListItems" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="GroceryListItem" inverseName="sourceRecipes" inverseEntity="GroceryListItem"/>
+        <relationship name="household" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Household" inverseName="recipes" inverseEntity="Household"/>
+        <relationship name="ingredients" optional="YES" toMany="YES" deletionRule="Cascade" destinationEntity="Ingredient" inverseName="recipe" inverseEntity="Ingredient"/>
+        <relationship name="plannedMeals" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="PlannedMeal" inverseName="recipe" inverseEntity="PlannedMeal"/>
+        <fetchIndex name="byPropertyIndex">
+            <fetchIndexElement property="usageCount" type="Binary" order="ascending"/>
+            <fetchIndexElement property="lastUsed" type="Binary" order="ascending"/>
+            <fetchIndexElement property="isFavorite" type="Binary" order="ascending"/>
+        </fetchIndex>
+    </entity>
+    <entity name="Store" representedClassName="Store" syncable="YES">
+        <attribute name="isDefault" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES"/>
+        <attribute name="color" optional="YES" attributeType="String"/>
+        <attribute name="dateCreated" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="householdKey" optional="YES" attributeType="String"/>
+        <attribute name="id" optional="YES" attributeType="UUID" usesScalarValueType="NO"/>
+        <attribute name="name" optional="YES" attributeType="String"/>
+        <attribute name="sortOrder" attributeType="Integer 16" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="updatedAt" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
+        <relationship name="groceryListItems" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="GroceryListItem" inverseName="store" inverseEntity="GroceryListItem"/>
+        <relationship name="household" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Household" inverseName="stores" inverseEntity="Household"/>
+        <relationship name="ingredientTemplates" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="IngredientTemplate" inverseName="preferredStore" inverseEntity="IngredientTemplate"/>
+        <fetchIndex name="byStoreSortOrder">
+            <fetchIndexElement property="sortOrder" type="Binary" order="ascending"/>
+            <fetchIndexElement property="name" type="Binary" order="ascending"/>
+        </fetchIndex>
+    </entity>
+    <entity name="UserPreferences" representedClassName="UserPreferences" syncable="YES">
+        <attribute name="autoNameMealPlans" attributeType="Boolean" defaultValueString="YES" usesScalarValueType="YES"/>
+        <attribute name="createdDate" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="id" optional="YES" attributeType="UUID" usesScalarValueType="NO"/>
+        <attribute name="mealPlanDuration" attributeType="Integer 16" defaultValueString="7" usesScalarValueType="YES"/>
+        <attribute name="mealPlanStartDay" attributeType="Integer 16" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="modifiedDate" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="showRecipeSources" attributeType="Boolean" defaultValueString="YES" usesScalarValueType="YES"/>
+        <relationship name="household" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Household" inverseName="preferences" inverseEntity="Household"/>
+        <fetchIndex name="byUserPreferencesId">
+            <fetchIndexElement property="id" type="Binary" order="ascending"/>
+        </fetchIndex>
+    </entity>
+    <entity name="WeeklyList" representedClassName="WeeklyList" syncable="YES">
+        <attribute name="dateCreated" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="householdKey" optional="YES" attributeType="String"/>
+        <attribute name="id" optional="YES" attributeType="UUID" usesScalarValueType="NO"/>
+        <attribute name="isCompleted" optional="YES" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES"/>
+        <attribute name="name" optional="YES" attributeType="String"/>
+        <attribute name="notes" optional="YES" attributeType="String"/>
+        <relationship name="household" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Household" inverseName="weeklyLists" inverseEntity="Household"/>
+        <relationship name="items" optional="YES" toMany="YES" deletionRule="Cascade" destinationEntity="GroceryListItem" inverseName="weeklyList" inverseEntity="GroceryListItem"/>
+    </entity>
+</model>

--- a/openspec/changes/no-store-default-entity/.openspec.yaml
+++ b/openspec/changes/no-store-default-entity/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-04-12

--- a/openspec/changes/no-store-default-entity/design.md
+++ b/openspec/changes/no-store-default-entity/design.md
@@ -1,0 +1,57 @@
+## Context
+
+Categories have a protected "Uncategorized" entity with `isDefault = true` (Category+CoreDataProperties). It's seeded by DefaultSeeder, protected from deletion in ManageCategoriesView, and used as the fallback when no category is assigned. The `lookupUncategorizedCategory()` method in IngredientTemplateService finds it by name + householdKey. DefaultSeeder creates it with sortOrder 999 and gray color (#9E9E9E).
+
+Stores currently have no equivalent. The Store entity has: id, name, color, sortOrder, householdKey, household, dateCreated, updatedAt, plus relationships to ingredientTemplates and groceryListItems. No `isDefault` flag exists — this requires a schema migration.
+
+The app is on Core Data schema v11. CloudKit Production schema is append-only (no destructive changes). Adding a boolean attribute with a default value is a safe lightweight migration.
+
+## Goals / Non-Goals
+
+**Goals:**
+- Add `isDefault: Bool` to Store entity (schema v12)
+- Seed a "No Store" entity on first launch and household creation
+- Protect "No Store" from deletion and renaming
+- Make "No Store" assignment an entity reference, not nil
+- Make `store = nil` mean "truly unassigned, needs attention"
+- Match the category Uncategorized pattern exactly
+
+**Non-Goals:**
+- Changing how categories work
+- Adding store assignment indicators/nudges (that's a separate change)
+- Changing the store management UI beyond protecting the default
+- Auto-migrating existing nil-store items to "No Store" (users should decide)
+
+## Decisions
+
+### 1. Schema v12: single attribute addition
+
+Add `isDefault: Bool` (default value: `false`, optional: no) to the Store entity. This is the same pattern as Category's `isDefault`. Lightweight migration handles this automatically. CloudKit Production schema accepts append-only attributes.
+
+Follow ADR 007 process: create new model version, add attribute, update codegen files.
+
+### 2. Seed alongside categories in DefaultSeeder
+
+Add "No Store" to DefaultSeeder, seeded in the same pass as default categories. Properties: name "No Store", color "#9E9E9E" (gray, same as Uncategorized), sortOrder 999, isDefault true. Uses the factory pattern via `performScopedWrite` for correct CloudKit store assignment.
+
+Add a `ensureNoStoreExists()` method parallel to `ensureUncategorizedExists()` for resilience on reinstall.
+
+### 3. Lookup by isDefault flag, not by name
+
+Create `StoreService.lookupDefaultStore()` that fetches by `isDefault == true AND householdKey == currentKey`. This is more robust than name matching since `isDefault` is a protected flag the user cannot change.
+
+**Alternative considered**: Lookup by name convention (`name == "No Store"`). Rejected because it's fragile if the name ever needs localization.
+
+### 4. StoreAssignmentModal: assign entity instead of nil
+
+The "No Store" button currently calls `assignStore(nil)`. Change to `assignStore(defaultStore)` where defaultStore is the "No Store" entity. The visual presentation stays the same: a "No Store" option at the top of the list.
+
+### 5. Do NOT auto-migrate existing nil items
+
+Existing items with `store = nil` stay as nil after migration. Users can assign them to "No Store" explicitly. This avoids surprising data changes and respects the user's current state.
+
+## Risks / Trade-offs
+
+- **[Risk] CloudKit sync timing on new device** → Default store might not exist yet on a fresh install before CloudKit syncs. Mitigation: `ensureNoStoreExists()` creates it locally before store operations.
+- **[Risk] Multiple "No Store" entities from multi-device seeding** → Same deduplication approach as categories: let each device seed, CloudKit syncs, deduplicator cleans up. Check if a StoreDeduplicator is needed (parallel to CategoryDeduplicator).
+- **[Trade-off] Existing nil items not auto-migrated** → Users may need to manually assign items. This is acceptable: the "No Store" option appears in the assignment modal, and items with nil still show in the "Unassigned" group until the user addresses them.

--- a/openspec/changes/no-store-default-entity/proposal.md
+++ b/openspec/changes/no-store-default-entity/proposal.md
@@ -1,0 +1,35 @@
+## Why
+
+Store assignment currently has no way to distinguish between "user hasn't assigned a store yet" and "user intentionally chose no specific store." Both states are `store = nil`. This means items like water or salt that a user deliberately leaves unassigned still trigger store-assignment nudges and show as "Unassigned" in grouping. Categories solved this with a protected "Uncategorized" entity: `categoryEntity = nil` means needs attention, `categoryEntity = Uncategorized` means settled. Stores need the same pattern.
+
+## What Changes
+
+- **Core Data schema v12**: Add `isDefault: Bool` attribute to Store entity (lightweight migration, append-only safe for CloudKit)
+- **Store+CoreDataProperties.swift**: Add `isDefault` managed property
+- **DefaultSeeder**: Seed a protected "No Store" entity (gray, sortOrder 999, isDefault true) alongside default categories
+- **StoreService**: Protect default store from deletion and renaming. Add lookup method for the default store.
+- **StoreAssignmentModal / StoreChangeModal**: "No Store" button assigns the "No Store" entity instead of setting `store = nil`
+- **New item default**: Items without a store get the "No Store" entity (like items get "Uncategorized" category)
+- **Store grouping**: "No Store" group uses the entity. `store = nil` means truly unassigned (shows indicator/nudge).
+- **ManageStoresView**: "No Store" appears in list but cannot be deleted or renamed
+
+## Capabilities
+
+### New Capabilities
+- `default-store`: Protected "No Store" entity with isDefault flag, mirroring the category "Uncategorized" pattern
+
+### Modified Capabilities
+- `store-aware-shopping`: Store assignment differentiates between "No Store" (settled) and nil (unassigned)
+- `grocery-lists`: Store grouping uses "No Store" entity name instead of "Unassigned" string
+
+## Impact
+
+- **Core Data model**: Schema v11 → v12 (add isDefault to Store). Lightweight migration, no data transformation.
+- **Models/Store+CoreDataProperties.swift**: Add `isDefault: Bool`
+- **Services/Persistence/DefaultSeeder.swift**: Seed "No Store" entry
+- **Services/StoreService.swift**: Protection logic, lookup method, default assignment
+- **Views/Grocery/StoreAssignmentModal.swift**: Assign entity instead of nil
+- **Views/Grocery/StoreChangeModal.swift**: Same
+- **Views/Grocery/ManageStoresView.swift**: Protection from delete/rename
+- **Services/GroceryListItemService.swift**: Default store assignment on new items
+- **CloudKit**: Append-only boolean attribute, safe for Production schema

--- a/openspec/changes/no-store-default-entity/specs/default-store/spec.md
+++ b/openspec/changes/no-store-default-entity/specs/default-store/spec.md
@@ -1,0 +1,30 @@
+## ADDED Requirements
+
+### Requirement: Store entity has isDefault flag
+The Store entity SHALL have an `isDefault: Bool` attribute that identifies the protected default store. Only one store per household SHALL have `isDefault = true`.
+
+#### Scenario: Schema migration
+- **WHEN** the app launches with schema v11 data
+- **THEN** lightweight migration adds `isDefault` attribute with default value `false` to all existing stores
+
+### Requirement: "No Store" entity seeded on first launch
+The system SHALL seed a "No Store" Store entity on first launch with `isDefault = true`, gray color (#9E9E9E), sortOrder 999. This entity SHALL be created during the same seeding pass as default categories.
+
+#### Scenario: Fresh install
+- **WHEN** the app launches for the first time
+- **THEN** a "No Store" entity is created alongside default categories
+
+#### Scenario: Reinstall / new device
+- **WHEN** the app launches and no default store exists locally
+- **THEN** `ensureNoStoreExists()` creates the "No Store" entity before any store operations
+
+### Requirement: Default store protected from deletion and renaming
+The "No Store" entity SHALL NOT be deletable or renamable by the user. It SHALL always appear in the store management view.
+
+#### Scenario: User attempts to delete default store
+- **WHEN** the user tries to delete the "No Store" entry in ManageStoresView
+- **THEN** the delete action is not available or is blocked
+
+#### Scenario: User attempts to rename default store
+- **WHEN** the user tries to rename the "No Store" entry
+- **THEN** the rename action is not available or is blocked

--- a/openspec/changes/no-store-default-entity/specs/grocery-lists/spec.md
+++ b/openspec/changes/no-store-default-entity/specs/grocery-lists/spec.md
@@ -1,0 +1,12 @@
+## MODIFIED Requirements
+
+### Requirement: Store grouping uses "No Store" entity
+When store grouping is enabled, items assigned to the "No Store" entity SHALL appear in a "No Store" group (using the entity name). Items with `store = nil` SHALL appear in a separate "Unassigned" group.
+
+#### Scenario: Items with "No Store" entity
+- **WHEN** store grouping is on and items are assigned to the "No Store" entity
+- **THEN** they appear in a "No Store" group with gray color indicator
+
+#### Scenario: Mix of assigned, No Store, and nil
+- **WHEN** store grouping is on and items have a mix of specific stores, "No Store" entity, and nil
+- **THEN** groups appear in order: specific stores (by sortOrder), then "No Store", then "Unassigned"

--- a/openspec/changes/no-store-default-entity/specs/store-aware-shopping/spec.md
+++ b/openspec/changes/no-store-default-entity/specs/store-aware-shopping/spec.md
@@ -1,0 +1,17 @@
+## MODIFIED Requirements
+
+### Requirement: Store assignment distinguishes "No Store" from unassigned
+When a user selects "No Store" in the assignment modal, the system SHALL assign the "No Store" entity (not nil). Items with `store = nil` are truly unassigned and MAY show assignment indicators.
+
+#### Scenario: User explicitly chooses "No Store"
+- **WHEN** the user taps "No Store" in StoreAssignmentModal or StoreChangeModal
+- **THEN** the item's store is set to the "No Store" entity
+- **THEN** the item is considered store-resolved (no assignment nudge)
+
+#### Scenario: New item without store
+- **WHEN** a new grocery list item is created without a specific store
+- **THEN** the item's store is set to the "No Store" entity by default
+
+#### Scenario: Truly unassigned item
+- **WHEN** an item has `store = nil` (e.g., legacy data before migration)
+- **THEN** the item appears in an "Unassigned" group in store grouping

--- a/openspec/changes/no-store-default-entity/tasks.md
+++ b/openspec/changes/no-store-default-entity/tasks.md
@@ -1,0 +1,42 @@
+## 1. Schema v12 Migration
+
+- [x] 1.1 Create new Core Data model version (v12) from v11
+- [x] 1.2 Add `isDefault` attribute to Store entity: Bool, default value false, non-optional
+- [x] 1.3 Set v12 as current model version
+- [x] 1.4 Update Store+CoreDataProperties.swift: add `@NSManaged public var isDefault: Bool`
+
+## 2. Default Store Seeding
+
+- [x] 2.1 Add "No Store" to DefaultSeeder: name "No Store", color "#9E9E9E", sortOrder 999, isDefault true
+- [x] 2.2 Add `ensureNoStoreExists(in:)` method to DefaultSeeder (parallel to `ensureUncategorizedExists`)
+- [x] 2.3 Call `ensureNoStoreExists` from PersistenceController and HouseholdService (same places that call ensureUncategorizedExists)
+
+## 3. StoreService Updates
+
+- [x] 3.1 Add `lookupDefaultStore()` method: fetch by `isDefault == true AND householdKey`
+- [x] 3.2 Add deletion protection: prevent deleting stores where `isDefault == true`
+- [x] 3.3 Add rename protection: ManageStoresView filters out isDefault stores from list
+
+## 4. Store Assignment UI
+
+- [x] 4.1 Update StoreAssignmentModal: "No Store" button assigns the default store entity instead of nil
+- [x] 4.2 Update StoreChangeModal: same change for bulk assignment
+- [x] 4.3 Update ManageStoresView: filter isDefault stores from management list
+
+## 5. Default Store on New Items
+
+- [x] 5.1 Update GroceryListItemService: resolveStore returns default "No Store" when no preferred store
+- [x] 5.2 Add lookupDefaultStore helper to GroceryListItemService
+
+## 6. Store Grouping Update
+
+- [x] 6.1 Store grouping works naturally: "No Store" entity items group under entity name, nil items still group as "Unassigned"
+- [x] 6.2 Ordering: specific stores by sortOrder, then "No Store" (sortOrder 999), then "Unassigned" at bottom
+
+## 7. Build and Verify
+
+- [x] 7.1 Build iOS target — confirm zero errors
+- [ ] 7.2 Test fresh install: "No Store" entity seeded alongside categories
+- [ ] 7.3 Test store assignment: "No Store" option assigns entity, not nil
+- [ ] 7.4 Test store grouping: "No Store" group and "Unassigned" group appear separately
+- [ ] 7.5 Test ManageStoresView: "No Store" cannot be deleted or renamed


### PR DESCRIPTION
## Summary
- Core Data schema v12: add `isDefault: Bool` to Store entity
- Seed protected "No Store" entity mirroring Category's "Uncategorized" pattern
- Differentiate intentional "no store" from unassigned items

## Changes
- Schema v12: isDefault attribute on Store (lightweight migration)
- DefaultSeeder: ensureNoStoreExists() alongside ensureUncategorizedExists()
- StoreService: lookupDefaultStore(), deletion protection
- StoreAssignmentModal + StoreChangeModal: assign entity instead of nil
- ManageStoresView: filter default stores from management list
- GroceryListItemService: resolveStore returns "No Store" when no preferred
- CloudKit Production schema deployed

## Test plan
- [x] iOS build succeeds
- [x] CloudKit schema deployed (CD_isDefault on CD_Store)
- [ ] Fresh install: "No Store" entity seeded
- [ ] Store assignment: "No Store" assigns entity, not nil
- [ ] Store grouping: "No Store" group shows correctly
- [ ] ManageStoresView: default store not visible in list