### PR TITLE
M18.2.1: Fix No Store as regular row with gray dot

### DIFF
--- a/forager/Views/Grocery/StoreAssignmentModal.swift
+++ b/forager/Views/Grocery/StoreAssignmentModal.swift
@@ -42,29 +42,8 @@ struct StoreAssignmentModal: View {
     var body: some View {
         NavigationStack {
             List {
-                // "No Store" option — assigns the default store entity
-                Button {
-                    assignStore(storeService.lookupDefaultStore())
-                } label: {
-                    HStack(spacing: ForagerTheme.Spacing.sm) {
-                        Circle()
-                            .strokeBorder(ForagerTheme.borderDefault, lineWidth: 1.5)
-                            .frame(width: 12, height: 12)
-                        Text("No Store")
-                            .font(ForagerTheme.bodyFont)
-                            .foregroundStyle(ForagerTheme.textSecondary)
-                        Spacer()
-                        if item.store?.isDefault == true {
-                            Image(systemName: "checkmark")
-                                .foregroundStyle(ForagerTheme.accentPrimary)
-                                .font(.caption)
-                        }
-                    }
-                }
-                .listRowBackground(Color.clear)
-
-                // Store options (exclude default "No Store")
-                ForEach(stores.filter { !$0.isDefault }) { store in
+                // All stores including "No Store" default entity
+                ForEach(stores) { store in
                     Button {
                         assignStore(store)
                     } label: {

--- a/forager/Views/Grocery/StoreChangeModal.swift
+++ b/forager/Views/Grocery/StoreChangeModal.swift
@@ -324,7 +324,7 @@ struct StorePickerView: View {
 
     var body: some View {
         List {
-            ForEach(stores.filter { !$0.isDefault }, id: \.objectID) { store in
+            ForEach(stores, id: \.objectID) { store in
                 Button {
                     onStoreSelected(store.objectID)
                     dismiss()
@@ -346,17 +346,6 @@ struct StorePickerView: View {
                 }
                 .buttonStyle(PlainButtonStyle())
             }
-
-            Button("No Store") {
-                // M18.2: Assign the default "No Store" entity instead of nil
-                if let defaultStore = stores.first(where: { $0.isDefault }) {
-                    onStoreSelected(defaultStore.objectID)
-                } else {
-                    onStoreSelected(nil)
-                }
-                dismiss()
-            }
-            .foregroundStyle(ForagerTheme.textSecondary)
         }
         .navigationTitle("Select Store")
         .navigationBarTitleDisplayMode(.inline)


### PR DESCRIPTION
## Summary
- Fix No Store not assigning entity (was falling back to nil)
- Show No Store as regular store row with gray color dot

## Changes
- StoreAssignmentModal: unified store list includes default, no separate button
- StoreChangeModal: same, removed filter that excluded isDefault

## Test plan
- [x] iOS build succeeds
- [ ] No Store shows with gray dot in both modals
- [ ] Assigning No Store sets entity (not nil), clears banner