### PR TITLE
M18.2.2: Fix No Store entity creation in household scope

### DIFF
--- a/Services/StoreService.swift
+++ b/Services/StoreService.swift
@@ -39,6 +39,8 @@ class StoreService: ObservableObject {
     /// One-time factory injection at app startup (ADR 014)
     func configure(factory: ManagedObjectFactory) {
         self.factory = factory
+        // M18.2: Ensure "No Store" default exists in current scope
+        _ = lookupDefaultStore()
     }
 
     // MARK: - CRUD
@@ -76,6 +78,7 @@ class StoreService: ObservableObject {
     }
 
     /// M18.2: Lookup the default "No Store" entity for the current household scope.
+    /// Creates it if it doesn't exist (handles household context where personal-only seeding misses it).
     func lookupDefaultStore() -> Store? {
         let request: NSFetchRequest<Store> = Store.fetchRequest()
         if let key = householdKeyProvider?() {
@@ -84,7 +87,34 @@ class StoreService: ObservableObject {
             request.predicate = NSPredicate(format: "isDefault == YES AND householdKey == nil")
         }
         request.fetchLimit = 1
-        return try? viewContext.fetch(request).first
+
+        if let existing = try? viewContext.fetch(request).first {
+            return existing
+        }
+
+        // Not found — create it in current scope using factory
+        guard let factory = factory else { return nil }
+        do {
+            let noStore = try factory.make(Store.self, configure: { s in
+                s.id = UUID()
+                s.name = "No Store"
+                s.color = "#9E9E9E"
+                s.sortOrder = 999
+                s.isDefault = true
+                s.dateCreated = Date()
+                s.updatedAt = Date()
+            })
+            try viewContext.save()
+            #if DEBUG
+            print("🏪 M18.2: Created 'No Store' default in household scope")
+            #endif
+            return noStore
+        } catch {
+            #if DEBUG
+            print("⚠️ M18.2: Failed to create default store: \(error)")
+            #endif
+            return nil
+        }
     }
 
     /// Deletes a store. If `reassignTo` is provided, templates currently assigned


### PR DESCRIPTION
## Summary
- No Store entity wasn't visible in household context (only seeded in personal store)
- lookupDefaultStore() now creates entity in household scope if missing

## Test plan
- [x] iOS build succeeds
- [ ] No Store appears in store picker for household users
- [ ] Assigning No Store clears the assignment banner