### PR TITLE
M18.2.3: Fix startup crash from No Store creation

### DIFF
--- a/Services/StoreService.swift
+++ b/Services/StoreService.swift
@@ -39,7 +39,10 @@ class StoreService: ObservableObject {
     /// One-time factory injection at app startup (ADR 014)
     func configure(factory: ManagedObjectFactory) {
         self.factory = factory
-        // M18.2: Ensure "No Store" default exists in current scope
+    }
+
+    /// M18.2: Ensure "No Store" default exists. Call after householdKeyProvider is set.
+    func ensureDefaultStoreExists() {
         _ = lookupDefaultStore()
     }
 

--- a/forager/App/foragerApp.swift
+++ b/forager/App/foragerApp.swift
@@ -157,6 +157,7 @@ struct foragerApp: App {
         storeSvc.householdKeyProvider = { [weak household] in
             household?.currentHouseholdKey
         }
+        storeSvc.ensureDefaultStoreExists()
         MealPlanService.shared.configure(factory: factory)
         MealPlanService.shared.configure(groceryListItemService: groceryItemSvc)
 


### PR DESCRIPTION
## Summary
- Fix crash on launch: lookupDefaultStore() called before householdKeyProvider set
- Move to ensureDefaultStoreExists() called after provider wiring

## Test plan
- [x] iOS build succeeds
- [ ] App launches without crash
- [ ] No Store appears in store picker