### PR TITLE
M18.2.4: Fix No Store seeding — mirror category pattern exactly

### DIFF
--- a/Services/Persistence/DefaultSeeder.swift
+++ b/Services/Persistence/DefaultSeeder.swift
@@ -172,29 +172,60 @@ final class DefaultSeeder {
 
     // MARK: - No Store Safety Net
 
-    /// M18.2: Ensure "No Store" default store exists in the personal store.
+    /// M18.2: Ensure "No Store" default store exists.
     /// Mirrors ensureUncategorizedExists for categories.
     /// Runs every startup — cheap fetch, no-op if it exists.
+    /// Creates in personal store (householdKey=nil). For existing households,
+    /// also checks the household scope and creates there if missing.
     static func ensureNoStoreExists(in context: NSManagedObjectContext) throws {
-        let request: NSFetchRequest<Store> = Store.fetchRequest()
-        request.predicate = NSPredicate(format: "isDefault == YES AND householdKey == nil")
-        request.fetchLimit = 1
+        // Personal store
+        let personalRequest: NSFetchRequest<Store> = Store.fetchRequest()
+        personalRequest.predicate = NSPredicate(format: "isDefault == YES AND householdKey == nil")
+        personalRequest.fetchLimit = 1
 
-        let existing = (try? context.fetch(request))?.first
-        if existing != nil { return }
+        if (try? context.fetch(personalRequest))?.first == nil {
+            let noStore = Store(context: context)
+            noStore.id = UUID()
+            noStore.name = "No Store"
+            noStore.color = "#9E9E9E"
+            noStore.sortOrder = 999
+            noStore.isDefault = true
+            noStore.dateCreated = Date()
+            noStore.updatedAt = Date()
 
-        let noStore = Store(context: context)
-        noStore.id = UUID()
-        noStore.name = "No Store"
-        noStore.color = "#9E9E9E"
-        noStore.sortOrder = 999
-        noStore.isDefault = true
-        noStore.dateCreated = Date()
-        noStore.updatedAt = Date()
+            #if DEBUG
+            print("🏪 M18.2: Created 'No Store' default in personal store")
+            #endif
+        }
 
-        #if DEBUG
-        print("🏪 M18.2: Created missing 'No Store' default store in personal store")
-        #endif
+        // Also check any household scope — for existing households that predate this feature
+        let householdRequest: NSFetchRequest<Store> = Store.fetchRequest()
+        householdRequest.predicate = NSPredicate(format: "isDefault == YES AND householdKey != nil")
+        householdRequest.fetchLimit = 1
+
+        if (try? context.fetch(householdRequest))?.first == nil {
+            // Check if user is in a household by looking for any store with a householdKey
+            let anyHouseholdStore: NSFetchRequest<Store> = Store.fetchRequest()
+            anyHouseholdStore.predicate = NSPredicate(format: "householdKey != nil")
+            anyHouseholdStore.fetchLimit = 1
+
+            if let existingStore = (try? context.fetch(anyHouseholdStore))?.first,
+               let householdKey = existingStore.householdKey {
+                let noStore = Store(context: context)
+                noStore.id = UUID()
+                noStore.name = "No Store"
+                noStore.color = "#9E9E9E"
+                noStore.sortOrder = 999
+                noStore.isDefault = true
+                noStore.householdKey = householdKey
+                noStore.dateCreated = Date()
+                noStore.updatedAt = Date()
+
+                #if DEBUG
+                print("🏪 M18.2: Created 'No Store' default in household scope (\(householdKey))")
+                #endif
+            }
+        }
     }
 
     // MARK: - Category Seeding (Phase 3.1: Using Repository)

--- a/Services/StoreService.swift
+++ b/Services/StoreService.swift
@@ -41,11 +41,6 @@ class StoreService: ObservableObject {
         self.factory = factory
     }
 
-    /// M18.2: Ensure "No Store" default exists. Call after householdKeyProvider is set.
-    func ensureDefaultStoreExists() {
-        _ = lookupDefaultStore()
-    }
-
     // MARK: - CRUD
 
     /// Creates a new store with the given name and color.
@@ -81,7 +76,6 @@ class StoreService: ObservableObject {
     }
 
     /// M18.2: Lookup the default "No Store" entity for the current household scope.
-    /// Creates it if it doesn't exist (handles household context where personal-only seeding misses it).
     func lookupDefaultStore() -> Store? {
         let request: NSFetchRequest<Store> = Store.fetchRequest()
         if let key = householdKeyProvider?() {
@@ -90,34 +84,7 @@ class StoreService: ObservableObject {
             request.predicate = NSPredicate(format: "isDefault == YES AND householdKey == nil")
         }
         request.fetchLimit = 1
-
-        if let existing = try? viewContext.fetch(request).first {
-            return existing
-        }
-
-        // Not found — create it in current scope using factory
-        guard let factory = factory else { return nil }
-        do {
-            let noStore = try factory.make(Store.self, configure: { s in
-                s.id = UUID()
-                s.name = "No Store"
-                s.color = "#9E9E9E"
-                s.sortOrder = 999
-                s.isDefault = true
-                s.dateCreated = Date()
-                s.updatedAt = Date()
-            })
-            try viewContext.save()
-            #if DEBUG
-            print("🏪 M18.2: Created 'No Store' default in household scope")
-            #endif
-            return noStore
-        } catch {
-            #if DEBUG
-            print("⚠️ M18.2: Failed to create default store: \(error)")
-            #endif
-            return nil
-        }
+        return try? viewContext.fetch(request).first
     }
 
     /// Deletes a store. If `reassignTo` is provided, templates currently assigned

--- a/forager/App/foragerApp.swift
+++ b/forager/App/foragerApp.swift
@@ -157,7 +157,6 @@ struct foragerApp: App {
         storeSvc.householdKeyProvider = { [weak household] in
             household?.currentHouseholdKey
         }
-        storeSvc.ensureDefaultStoreExists()
         MealPlanService.shared.configure(factory: factory)
         MealPlanService.shared.configure(groceryListItemService: groceryItemSvc)
 


### PR DESCRIPTION
## Summary
- Fix crash: remove eager creation at init, match category seeding pattern
- ensureNoStoreExists handles personal + household scopes
- No factory, no lazy, no crash — direct Store(context:) like categories

## Test plan
- [x] iOS build succeeds
- [ ] App launches without crash
- [ ] No Store appears in store picker with gray dot
- [ ] Assigning No Store clears assignment banner