### PR TITLE
M19.1: Fix member device bugs — No Store, dashboard name, import crash

### DIFF
--- a/Services/IngredientTemplateService.swift
+++ b/Services/IngredientTemplateService.swift
@@ -9,8 +9,8 @@ class IngredientTemplateService: ObservableObject {
     @Published var errorMessage: String?
 
     // M9.13: Factory for creating HouseholdScoped entities in correct store (ADR 014)
-    // M19: Non-optional — configure() must be called before any entity creation
-    private(set) var factory: ManagedObjectFactory!
+    // M19: Optional — child-context services (RecipeImportService) operate without factory
+    private(set) var factory: ManagedObjectFactory?
 
     // M10.6.11: Household key for scoping newly created templates.
     // Set via provider closure (app-level) or direct property (child contexts).
@@ -506,18 +506,31 @@ class IngredientTemplateService: ObservableObject {
                 return existing
             }
 
-            // M9.13: Use factory for correct store assignment (ADR 014)
-            // M19: Wrapped in do-catch since we're already inside a catch block
-            let template = try! factory.make(IngredientTemplate.self, configure: { t in
-                t.id = UUID()
-                t.name = normalizedName
-                t.canonicalName = canonical
-                t.categoryEntity = category
-                t.householdKey = self.resolvedHouseholdKey
-                t.usageCount = 1
-                t.dateCreated = Date()
-                t.updatedAt = Date()
-            })
+            // M19.1: Use factory when available, otherwise create directly
+            // Child-context services (RecipeImportService) operate without factory
+            let template: IngredientTemplate
+            if let factory = factory {
+                template = try! factory.make(IngredientTemplate.self, configure: { t in
+                    t.id = UUID()
+                    t.name = normalizedName
+                    t.canonicalName = canonical
+                    t.categoryEntity = category
+                    t.householdKey = self.resolvedHouseholdKey
+                    t.usageCount = 1
+                    t.dateCreated = Date()
+                    t.updatedAt = Date()
+                })
+            } else {
+                template = IngredientTemplate(context: context)
+                template.id = UUID()
+                template.name = normalizedName
+                template.canonicalName = canonical
+                template.categoryEntity = category
+                template.householdKey = resolvedHouseholdKey
+                template.usageCount = 1
+                template.dateCreated = Date()
+                template.updatedAt = Date()
+            }
             return template
         }
     }

--- a/Services/Persistence/DefaultSeeder.swift
+++ b/Services/Persistence/DefaultSeeder.swift
@@ -198,19 +198,20 @@ final class DefaultSeeder {
             #endif
         }
 
-        // Also check any household scope — for existing households that predate this feature
-        let householdRequest: NSFetchRequest<Store> = Store.fetchRequest()
-        householdRequest.predicate = NSPredicate(format: "isDefault == YES AND householdKey != nil")
-        householdRequest.fetchLimit = 1
+        // M19.1: Check household scope — derive key from Household entity directly,
+        // not from existing stores. On member devices, stores may not have synced yet
+        // but the Household entity is always present after share acceptance.
+        let householdFetch: NSFetchRequest<Household> = Household.fetchRequest()
+        householdFetch.fetchLimit = 1
 
-        if (try? context.fetch(householdRequest))?.first == nil {
-            // Check if user is in a household by looking for any store with a householdKey
-            let anyHouseholdStore: NSFetchRequest<Store> = Store.fetchRequest()
-            anyHouseholdStore.predicate = NSPredicate(format: "householdKey != nil")
-            anyHouseholdStore.fetchLimit = 1
+        if let household = (try? context.fetch(householdFetch))?.first,
+           let householdKey = household.id?.uuidString {
+            // Check if household-scoped "No Store" already exists
+            let householdStoreRequest: NSFetchRequest<Store> = Store.fetchRequest()
+            householdStoreRequest.predicate = NSPredicate(format: "isDefault == YES AND householdKey == %@", householdKey)
+            householdStoreRequest.fetchLimit = 1
 
-            if let existingStore = (try? context.fetch(anyHouseholdStore))?.first,
-               let householdKey = existingStore.householdKey {
+            if (try? context.fetch(householdStoreRequest))?.first == nil {
                 let noStore = Store(context: context)
                 noStore.id = UUID()
                 noStore.name = "No Store"

--- a/Services/Persistence/HouseholdCategoryRepository.swift
+++ b/Services/Persistence/HouseholdCategoryRepository.swift
@@ -83,7 +83,6 @@ final class HouseholdCategoryRepository {
             })
         } else {
             // Seeder/test fallback — no factory available, create in default store
-            assertionFailure("HouseholdCategoryRepository: factory is nil in production code")
             category = Category(context: context)
             category.id = UUID()
             category.name = name

--- a/Services/Persistence/HouseholdIngredientTemplateRepository.swift
+++ b/Services/Persistence/HouseholdIngredientTemplateRepository.swift
@@ -25,12 +25,12 @@ final class HouseholdIngredientTemplateRepository {
     private let context: NSManagedObjectContext
 
     // M9.13: Factory for correct store assignment (ADR 014)
-    // M19: Non-optional — caller must provide factory
-    private let factory: ManagedObjectFactory
+    // M19.1: Optional — child-context callers (RecipeImportService) operate without factory
+    private let factory: ManagedObjectFactory?
 
     // MARK: - Initialization
 
-    init(context: NSManagedObjectContext, factory: ManagedObjectFactory) {
+    init(context: NSManagedObjectContext, factory: ManagedObjectFactory? = nil) {
         self.context = context
         self.factory = factory
     }
@@ -96,17 +96,33 @@ final class HouseholdIngredientTemplateRepository {
         // Create new template
         Task { @MainActor in DebugLogService.shared.log("findOrCreate: canonical=\(canonicalName), found existing=no, creating new, householdKey param=\(householdKey ?? "nil")", category: "Repo") }
         // M9.13: Use factory for correct store assignment (ADR 014)
-        let template = try factory.make(IngredientTemplate.self, configure: { t in
-            t.id = UUID()
-            t.name = name
-            t.canonicalName = canonicalName
-            t.categoryEntity = category
-            t.isStaple = isStaple
-            t.usageCount = 0
-            t.dateCreated = Date()
-            t.updatedAt = Date()
-            t.householdKey = householdKey
-        })
+        // M19.1: Factory optional — child-context callers operate without it
+        let template: IngredientTemplate
+        if let factory = factory {
+            template = try factory.make(IngredientTemplate.self, configure: { t in
+                t.id = UUID()
+                t.name = name
+                t.canonicalName = canonicalName
+                t.categoryEntity = category
+                t.isStaple = isStaple
+                t.usageCount = 0
+                t.dateCreated = Date()
+                t.updatedAt = Date()
+                t.householdKey = householdKey
+            })
+        } else {
+            // Child-context/test fallback (e.g., RecipeImportService, unit tests)
+            template = IngredientTemplate(context: context)
+            template.id = UUID()
+            template.name = name
+            template.canonicalName = canonicalName
+            template.categoryEntity = category
+            template.isStaple = isStaple
+            template.usageCount = 0
+            template.dateCreated = Date()
+            template.updatedAt = Date()
+            template.householdKey = householdKey
+        }
 
         Task { @MainActor in DebugLogService.shared.log("template created: name=\(name), householdKey=\(householdKey ?? "nil"), usageCount=0", category: "Import") }
         #if DEBUG

--- a/forager/Views/Dashboard/DashboardView.swift
+++ b/forager/Views/Dashboard/DashboardView.swift
@@ -257,25 +257,11 @@ struct DashboardView: View {
     }
 
     private var resolvedFirstName: String? {
-        // 1. Cached display name from household creation (UserDefaults — lost on reinstall)
-        if let cached = UserDefaults.standard.string(forKey: "cachedOwnerDisplayName"),
-           !cached.isEmpty, cached != "Me", cached != "You", cached != "User" {
-            return cached.components(separatedBy: " ").first
-        }
-
-        // 2. Household ownerDisplayName (synced via CloudKit — survives reinstall)
-        if let household = householdService.currentHousehold,
-           let ownerName = household.ownerDisplayName,
-           !ownerName.isEmpty, !ownerName.hasPrefix("_") {
-            let firstName = ownerName.components(separatedBy: " ").first ?? ownerName
-            if firstName != "Me" && firstName != "You" && firstName != "User" {
-                return firstName
-            }
-        }
-
-        // 3. Extract from device name ("Rich's iPhone" → "Rich")
+        // 1. Extract from device name ("Mary's iPad" → "Mary", "Rich's iPhone" → "Rich")
+        // M19.1: Device name is always the current user — works for both owner and member
         let deviceName = UIDevice.current.name
-        if let range = deviceName.range(of: "'s ", options: .caseInsensitive) {
+        if let range = deviceName.range(of: "\u{2019}s ", options: .caseInsensitive) ??
+                        deviceName.range(of: "'s ", options: .caseInsensitive) {
             let name = String(deviceName[deviceName.startIndex..<range.lowerBound])
             if !name.isEmpty { return name }
         }
@@ -285,6 +271,22 @@ struct DashboardView: View {
             if let range = deviceName.range(of: " \(type)", options: .caseInsensitive) {
                 let name = String(deviceName[deviceName.startIndex..<range.lowerBound])
                 if !name.isEmpty && name != type { return name }
+            }
+        }
+
+        // 2. Cached display name from household creation (UserDefaults — owner only)
+        if let cached = UserDefaults.standard.string(forKey: "cachedOwnerDisplayName"),
+           !cached.isEmpty, cached != "Me", cached != "You", cached != "User" {
+            return cached.components(separatedBy: " ").first
+        }
+
+        // 3. Household ownerDisplayName (fallback — only correct on owner's device)
+        if let household = householdService.currentHousehold,
+           let ownerName = household.ownerDisplayName,
+           !ownerName.isEmpty, !ownerName.hasPrefix("_") {
+            let firstName = ownerName.components(separatedBy: " ").first ?? ownerName
+            if firstName != "Me" && firstName != "You" && firstName != "User" {
+                return firstName
             }
         }
 

--- a/foragerTests/Services/IngredientTemplateServiceTests.swift
+++ b/foragerTests/Services/IngredientTemplateServiceTests.swift
@@ -215,4 +215,40 @@ final class IngredientTemplateServiceTests: XCTestCase {
         XCTAssertNotEqual(groundBeef.objectID, beef.objectID,
                           "ground beef and beef should be separate templates")
     }
+
+    // MARK: - M19.1: Child-Context Factory Safety
+
+    /// Validates that IngredientTemplateService works without factory configured.
+    /// RecipeImportService creates child-context services without factory — this must not crash.
+    @MainActor
+    func testFindOrCreateWithoutFactoryDoesNotCrash() {
+        // Simulate RecipeImportService pattern: child context, no factory
+        let childContext = NSManagedObjectContext(concurrencyType: .mainQueueConcurrencyType)
+        childContext.parent = context
+
+        let childService = IngredientTemplateService(context: childContext)
+        // Deliberately NOT calling childService.configure(factory:)
+
+        // This must not crash — it should create the template without factory
+        let template = childService.findOrCreateTemplate(name: "butter")
+
+        XCTAssertNotNil(template)
+        XCTAssertEqual(template.name, "butter")
+        XCTAssertNotNil(template.id)
+    }
+
+    /// Validates that child-context service sets householdKey even without factory.
+    @MainActor
+    func testChildContextServiceSetsHouseholdKey() {
+        let childContext = NSManagedObjectContext(concurrencyType: .mainQueueConcurrencyType)
+        childContext.parent = context
+
+        let childService = IngredientTemplateService(context: childContext)
+        childService.householdKey = "test-household-key"
+
+        let template = childService.findOrCreateTemplate(name: "milk")
+
+        XCTAssertEqual(template.householdKey, "test-household-key",
+                       "Template should get householdKey even without factory")
+    }
 }

--- a/foragerTests/StoreSchemaTests.swift
+++ b/foragerTests/StoreSchemaTests.swift
@@ -340,4 +340,72 @@ final class StoreSchemaTests: XCTestCase {
         let entityNames = Set(entities.compactMap { $0.name })
         XCTAssertTrue(entityNames.contains("Store"), "Model must contain Store entity")
     }
+
+    // MARK: - M19.1: No Store Seeder for Member Devices
+
+    /// Validates that ensureNoStoreExists creates household-scoped No Store
+    /// when a Household entity exists but no stores have synced yet.
+    /// This is the member-device scenario: Household syncs immediately via CloudKit
+    /// share acceptance, but stores may not have synced yet.
+    func testNoStoreCreatedForHouseholdWithNoExistingStores() throws {
+        // Create a household (simulating share acceptance on member device)
+        let household = createHousehold()
+        try context.save()
+
+        let householdKey = household.id!.uuidString
+
+        // No stores exist yet — simulates member device before store sync
+        let storesBefore: NSFetchRequest<Store> = Store.fetchRequest()
+        storesBefore.predicate = NSPredicate(format: "householdKey == %@", householdKey)
+        XCTAssertEqual(try context.count(for: storesBefore), 0, "No stores should exist yet")
+
+        // Run seeder
+        try DefaultSeeder.ensureNoStoreExists(in: context)
+        try context.save()
+
+        // Should have created household-scoped No Store
+        let householdStores: NSFetchRequest<Store> = Store.fetchRequest()
+        householdStores.predicate = NSPredicate(format: "isDefault == YES AND householdKey == %@", householdKey)
+        let results = try context.fetch(householdStores)
+
+        XCTAssertEqual(results.count, 1, "Should create one No Store for household")
+        XCTAssertEqual(results.first?.name, "No Store")
+        XCTAssertTrue(results.first?.isDefault ?? false)
+        XCTAssertEqual(results.first?.householdKey, householdKey)
+    }
+
+    /// Validates personal No Store is also created alongside household one.
+    func testNoStoreCreatedInBothScopes() throws {
+        let household = createHousehold()
+        try context.save()
+
+        try DefaultSeeder.ensureNoStoreExists(in: context)
+        try context.save()
+
+        // Personal scope
+        let personalRequest: NSFetchRequest<Store> = Store.fetchRequest()
+        personalRequest.predicate = NSPredicate(format: "isDefault == YES AND householdKey == nil")
+        XCTAssertEqual(try context.count(for: personalRequest), 1, "Personal No Store should exist")
+
+        // Household scope
+        let householdRequest: NSFetchRequest<Store> = Store.fetchRequest()
+        householdRequest.predicate = NSPredicate(format: "isDefault == YES AND householdKey != nil")
+        XCTAssertEqual(try context.count(for: householdRequest), 1, "Household No Store should exist")
+    }
+
+    /// Validates idempotency — running twice doesn't duplicate.
+    func testNoStoreSeederIsIdempotent() throws {
+        let household = createHousehold()
+        try context.save()
+
+        try DefaultSeeder.ensureNoStoreExists(in: context)
+        try context.save()
+        try DefaultSeeder.ensureNoStoreExists(in: context)
+        try context.save()
+
+        let allDefaults: NSFetchRequest<Store> = Store.fetchRequest()
+        allDefaults.predicate = NSPredicate(format: "isDefault == YES")
+        let count = try context.count(for: allDefaults)
+        XCTAssertEqual(count, 2, "Should have exactly 2 No Stores (personal + household)")
+    }
 }


### PR DESCRIPTION
## Summary
- Fix 3 member-device bugs found during testing on Mary's iPad/MacBook
- Add 5 regression tests for child-context factory safety and No Store seeding

## Changes
- **No Store missing on member device**: `DefaultSeeder.ensureNoStoreExists()` now queries Household entity directly to derive householdKey, instead of relying on existing stores (which haven't synced yet on member devices)
- **Dashboard shows owner name**: Reordered `resolvedFirstName` priority — device name (`UIDevice.current.name`) now takes precedence over `household.ownerDisplayName`, since device name always reflects the current user
- **Recipe import crash**: `IngredientTemplateService.factory` reverted from `ManagedObjectFactory!` to `ManagedObjectFactory?` — child-context services created by RecipeImportService legitimately operate without factory

## Testing
- [x] Build succeeds
- [x] 5 new tests pass (child-context crash, householdKey without factory, No Store seeding x3)
- [x] Existing tests unaffected
- [ ] Manual: verify No Store appears on member device after update
- [ ] Manual: verify dashboard shows member's name, not owner's