### PR TITLE
M7.7.1: Fix shopping list sheet and redundant ingredient amounts

### DIFF
--- a/forager/Components/SelectListSheet.swift
+++ b/forager/Components/SelectListSheet.swift
@@ -192,20 +192,16 @@ struct SelectListSheet: View {
     // MARK: - View Components
     
     private var emptyStateView: some View {
-        VStack(spacing: 20) {
-            Image(systemName: "cart")
-                .font(.system(size: 50))
-                .foregroundStyle(ForagerTheme.textSecondary)
-            
-            Text("No Shopping Lists")
-                .font(.title3)
-                .fontWeight(.semibold)
-            
-            Text("Create your first list to get started")
+        VStack(spacing: 8) {
+            Text("No existing lists")
                 .font(.subheadline)
                 .foregroundStyle(ForagerTheme.textSecondary)
+            Text("Tap below to create one")
+                .font(.caption)
+                .foregroundStyle(ForagerTheme.textTertiary)
         }
-        .frame(maxHeight: .infinity)
+        .frame(maxWidth: .infinity)
+        .padding(.vertical, ForagerTheme.Spacing.lg)
     }
     
     private var listSelectionView: some View {

--- a/forager/Views/MealPlanning/MealPlanIngredientSelectionView.swift
+++ b/forager/Views/MealPlanning/MealPlanIngredientSelectionView.swift
@@ -167,12 +167,6 @@ struct MealPlanIngredientSelectionView: View {
                 }
 
                 Spacer()
-
-                if let displayText = ingredient.displayText, !displayText.isEmpty {
-                    Text(displayText)
-                        .font(ForagerTheme.captionFont)
-                        .foregroundStyle(ForagerTheme.textSecondary)
-                }
             }
         }
         .buttonStyle(.plain)


### PR DESCRIPTION
## Summary
- Fix SelectListSheet empty state covering recipes when adding from meal plan
- Remove redundant quantity display in ingredient selection view

## Changes
- **SelectListSheet**: Replace full-height empty state (cart icon + large text) with compact two-line message so all recipes remain visible
- **MealPlanIngredientSelectionView**: Remove `displayText` amount from right side of ingredient rows — the ingredient name already includes the quantity (e.g., "24 oz chicken breast")

## Testing
- [x] Build succeeds
- [ ] Add to grocery list from meal plan with no existing lists — recipes all visible
- [ ] Ingredient selection shows clean rows without redundant amounts