### PR TITLE
docs: memory-sweep promotions (3 committed docs)

### DIFF
--- a/docs/app-store-resubmit-workflow.md
+++ b/docs/app-store-resubmit-workflow.md
@@ -1,0 +1,36 @@
+# App Store — Resubmit vs. Reply after a rejection
+
+App Review rejections resolve two different ways depending on the rejection
+**type**. Picking the wrong path costs days (it once cost a 3-day stall and a
+support phone call). Check the type first, then follow the matching path.
+
+## Metadata rejections
+Guideline 2.3.6 (Accurate Metadata), Age Rating issues, description / screenshot
+/ keyword problems — anything whose status is **"Metadata Rejected"** and whose
+fix lives entirely in App Store Connect.
+
+1. Update the metadata in ASC.
+2. Reply to the reviewer in Resolution Center.
+3. **Apple continues the review from the reply — no resubmit, no new binary.**
+
+This is documented Apple behavior and confirmed across community sources. Do
+**not** generalize the Cancel/Resubmit dance below to metadata rejections.
+
+## Binary / guideline rejections
+Code-level issues, functional complaints — status **"Rejected."**
+
+1. Fix the code, archive a new build (or reuse the same build if permitted).
+2. Explicitly **Submit for Review**.
+3. If the Resubmit button is disabled, click **Cancel Submission** on the
+   rejected submission to unlock it.
+
+## Rule of thumb
+- Fix is only in ASC (ratings, descriptions, screenshots, keywords, privacy) →
+  **reply + update metadata**, done.
+- A code change / new binary is involved → **archive, upload, resubmit** (may
+  need Cancel Submission to unlock Resubmit).
+- When unsure, default to the **less-destructive path** (reply first) and
+  escalate only if the status doesn't change within a reasonable window.
+
+---
+*Promoted from auto-memory during the 2026-07-10 memory sweep.*

--- a/docs/deferred-work.md
+++ b/docs/deferred-work.md
@@ -1,0 +1,20 @@
+# Deferred work
+
+Intentionally-deferred engineering items — extracted here so they survive
+outside session memory and surface during future planning. Add new items as
+they're deferred; remove them when shipped.
+
+## Recipe entity fields — `description`, `cuisine`, `category`
+**Deferred; extraction already done.** The import pipeline (`ImportDraftRecipe`)
+already extracts `description`, `cuisine`, and `category`, but they are dropped
+in `toRecipeFormData()` at save time and never persisted.
+
+- **Why deferred:** schema v11 (M18) only added `imageURL` and `author` (legal
+  attribution). The rest add user value but weren't needed for launch.
+- **To ship:** append-only migration adding the optional String attributes, then
+  wire them through `RecipeImportService.saveImport()` (~line 182). **No new
+  extraction work needed** — the values are already available in
+  `ImportDraftRecipe`. Natural fit for a "recipe detail" redesign.
+
+---
+*Seeded from auto-memory during the 2026-07-10 memory sweep.*

--- a/docs/mac-app-notes.md
+++ b/docs/mac-app-notes.md
@@ -1,0 +1,29 @@
+# Mac app — decision, config, and the CloudKit gotcha
+
+## Decision (2026-04-09): no separate macOS target
+The native macOS target (`foragerMac`, `NavigationSplitView` sidebar, its own
+bundle ID `com.richhayn.foragerMac`, separate App Store listing) was **scrapped**.
+The iOS app runs on Apple Silicon Macs via compatibility, and CloudKit
+Production sync works there fully.
+
+**Path forward:** set `SUPPORTS_MAC_DESIGNED_FOR_IPHONE_IPAD = YES` on the iOS
+target — this makes the existing iOS/iPad app available on the Mac App Store
+with no separate target, scheme, or platform polyfills. The old `foragerMac` ASC
+record (ID `6761905908`) exists but is not needed.
+
+## The gotcha that caused a sync-debugging rabbit hole
+**Locally-built macOS apps always use CloudKit *Sandbox* (Development), never
+Production.** Only TestFlight / App Store builds get Production CloudKit. If Mac
+data "won't sync" or looks empty in a local build, this is almost always why —
+check the environment before chasing a real bug.
+
+## Obsolete note (kept for context)
+An earlier memory tracked missing **Push Notifications** and **App Sandbox**
+capabilities on the `foragerMac` target. That target is scrapped, so the note is
+moot — but if a separate Mac target is ever revived, those capabilities must be
+configured for the App ID at developer.apple.com first (they weren't offered in
+Xcode's capability picker without prior portal setup).
+
+---
+*Promoted from auto-memory (`m19-scrapped`, `macos-deferred`) during the
+2026-07-10 memory sweep.*


### PR DESCRIPTION
Part of the 2026-07-10 memory sweep. Promotes durable engineering truth out of auto-memory into committed docs **before** the source memories are retired, per the knowledge-boundary rule (PR #158):

- `docs/app-store-resubmit-workflow.md` — reply-vs-resubmit runbook (metadata reply continues review; binary rejection needs resubmit + maybe Cancel Submission).
- `docs/mac-app-notes.md` — the 2026-04-09 'Designed for iPad, no separate macOS target' decision + the *local Mac builds use CloudKit Sandbox, not Production* gotcha.
- `docs/deferred-work.md` — Recipe `description`/`cuisine`/`category` are extracted but unpersisted; append-only migration when a recipe-detail redesign lands.

Duplicates NOT re-documented (already committed): multi-zone bug (insights-log 43–47 + ADR 014), OpenSpec naming (workflow-reference), prefix convention (naming-standards).